### PR TITLE
Add A5 heater protocol support (UltraTemp/MasterTemp, action 0x72/0x73)

### DIFF
--- a/components/opnpool/core/poolstate_rx.cpp
+++ b/components/opnpool/core/poolstate_rx.cpp
@@ -1058,6 +1058,12 @@ update_state(network_msg_t const * const msg, poolstate_t * const new_state)
             break;
         case network_msg_typ_t::CTRL_CHEM_REQ:
             break;
+        case network_msg_typ_t::HEATER_SET:
+            _ctrl_hex_bytes(dbg, msg->u.raw, sizeof(network_heater_set_t));
+            break;
+        case network_msg_typ_t::HEATER_RESP:
+            _ctrl_hex_bytes(dbg, msg->u.raw, sizeof(network_heater_resp_t));
+            break;
         case network_msg_typ_t::CHLOR_CONTROL_REQ:
             _chlor_control_req(dbg, &msg->u.ic.chlor_control_req);
             break;

--- a/components/opnpool/pool_task/datalink.h
+++ b/components/opnpool/pool_task/datalink.h
@@ -71,6 +71,8 @@ struct datalink_addr_t {
     static constexpr uint8_t CHLORINATOR          = 0x50;
     static constexpr uint8_t PUMP_BASE            = 0x60;  ///< base value for pump addresses
     static constexpr uint8_t PUMP_ID_MASK         = 0x0F;  ///< mask to extract pump ID (low nibble)
+    static constexpr uint8_t HEATER_BASE          = 0x70;  ///< base value for heater addresses (UltraTemp, MasterTemp)
+    static constexpr uint8_t HEATER_ID_MASK       = 0x0F;  ///< mask to extract heater ID (low nibble)
     static constexpr uint8_t BROADCAST            = 0x0F;  ///< broadcast address
     static constexpr uint8_t UNKNOWN_90           = 0x90;
 
@@ -90,6 +92,7 @@ struct datalink_addr_t {
     constexpr bool is_controller()  const { return (addr == SUNTOUCH_CONTROLLER || addr == EASYTOUCH_CONTROLLER); }
     constexpr bool is_remote()      const { return (addr == REMOTE || addr == WIRELESS_REMOTE || addr == QUICKTOUCH_REMOTE); }
     constexpr bool is_pump()        const { return (addr & 0xF0) == PUMP_BASE; }
+    constexpr bool is_heater()      const { return (addr & 0xF0) == HEATER_BASE; }
     constexpr bool is_unknown_90()  const { return addr == UNKNOWN_90; }
     constexpr bool is_chlorinator() const { return addr == CHLORINATOR; } 
     constexpr bool is_broadcast()   const { return addr == BROADCAST; }

--- a/components/opnpool/pool_task/datalink_pkt.h
+++ b/components/opnpool/pool_task/datalink_pkt.h
@@ -96,6 +96,8 @@ enum class datalink_ctrl_typ_t : uint8_t {
     DELAY_REQ        = 0xE3,
     HEAT_SETPT_RESP  = 0x28,
     HEAT_SETPT_REQ   = 0xE8,
+    HEATER_SET       = 0x72,  ///< Controller → heater: set operating mode (off/heat/cool)
+    HEATER_RESP      = 0x73,  ///< Heater → controller: current mode and status
     VERSION_RESP     = 0xFC,
     VERSION_REQ      = 0xFD
     // SPA_CTRL_REQ     = 0xD6,

--- a/components/opnpool/pool_task/network_msg.h
+++ b/components/opnpool/pool_task/network_msg.h
@@ -254,7 +254,31 @@ struct network_ctrl_delay_resp_t {
 } PACK8;
 
 struct network_ctrl_heat_setpt_resp_t {
-    uint8_t unknown[10];  // 00 00 00 00 00 00 00 00 00 00 
+    uint8_t unknown[10];  // 00 00 00 00 00 00 00 00 00 00
+} PACK8;
+
+/// @brief UltraTemp/MasterTemp heat pump operating modes.
+enum class network_heater_mode_t : uint8_t {
+    OFF  = 0x00,  ///< Heater off
+    HEAT = 0x01,  ///< Heat mode
+    COOL = 0x02,  ///< Cool mode
+};
+
+/// @brief Controller → heater command (action 0x72 / 114). Sets operating mode.
+struct network_heater_set_t {
+    uint8_t               cmd;         // 0  always 0x90
+    network_heater_mode_t mode;        // 1  0=off, 1=heat, 2=cool
+    uint8_t               unknown_2;   // 2
+    uint8_t               temp_offset; // 3  temperature offset
+    uint8_t               unknown[6];  // 4..9
+} PACK8;
+
+/// @brief Heater → controller response (action 0x73 / 115). Reports current mode and status.
+struct network_heater_resp_t {
+    uint8_t               cmd;        // 0  always 0xA0
+    network_heater_mode_t mode;       // 1  current operating mode
+    uint8_t               status;     // 2  heater status flags
+    uint8_t               unknown[7]; // 3..9
 } PACK8;
 
 struct network_ctrl_circ_names_req_t {
@@ -511,6 +535,8 @@ union network_data_a5_t {
     network_ctrl_solarpump_resp_t  ctrl_solarpump_resp;
     network_ctrl_delay_resp_t      ctrl_delay_resp;
     network_ctrl_heat_setpt_resp_t ctrl_heat_setpt_resp;
+    network_heater_set_t           heater_set;
+    network_heater_resp_t          heater_resp;
     network_ctrl_circ_names_req_t  ctrl_circ_names_req;
     network_ctrl_circ_names_resp_t ctrl_circ_names_resp;
     network_ctrl_scheds_req_t      ctrl_scheds_req;
@@ -598,6 +624,8 @@ union network_data_t {
     X(CTRL_SCHEDS_REQ,       sizeof(network_ctrl_scheds_req_t),     false, A5_CTRL, datalink_ctrl_typ_t::SCHEDS_REQ)    \
     X(CTRL_SCHEDS_RESP,      sizeof(network_ctrl_scheds_resp_t),    false, A5_CTRL, datalink_ctrl_typ_t::SCHEDS_RESP)   \
     X(CTRL_CHEM_REQ,         sizeof(network_ctrl_chem_req_t),       false, A5_CTRL, datalink_ctrl_typ_t::CHEM_REQ)      \
+    X(HEATER_SET,            sizeof(network_heater_set_t),          false, A5_CTRL, datalink_ctrl_typ_t::HEATER_SET)    \
+    X(HEATER_RESP,           sizeof(network_heater_resp_t),         false, A5_CTRL, datalink_ctrl_typ_t::HEATER_RESP)   \
     X(CHLOR_CONTROL_REQ,     sizeof(network_chlor_control_req_t),   false, IC,      datalink_chlor_typ_t::CONTROL_REQ)  \
     X(CHLOR_CONTROL_RESP,    sizeof(network_chlor_control_resp_t),  false, IC,      datalink_chlor_typ_t::CONTROL_RESP) \
     X(CHLOR_MODEL_REQ,       sizeof(network_chlor_model_req_t),     false, IC,      datalink_chlor_typ_t::MODEL_REQ)    \

--- a/components/opnpool/pool_task/network_rx.cpp
+++ b/components/opnpool/pool_task/network_rx.cpp
@@ -17,6 +17,7 @@
 
 #include <esp_system.h>
 #include <esp_types.h>
+#include <esp_log.h>
 #include <esphome/core/log.h>
 
 #include "utils/to_str.h"
@@ -85,7 +86,9 @@ _decode_msg_a5_ctrl(datalink_pkt_t const * const pkt, network_msg_t * const msg)
 
     network_msg_typ_info_t const * const info = network_msg_typ_get_info(datalink_ctrl_typ);
     if (info == nullptr) {
-        ESP_LOGW(TAG, "unsupported ctrl_typ (%s) ", enum_str(datalink_ctrl_typ));
+        ESP_LOGW(TAG, "unsupported ctrl_typ (%s) src=0x%02X dst=0x%02X len=%u",
+                 enum_str(datalink_ctrl_typ), pkt->src.addr, pkt->dst.addr, pkt->data_len);
+        ESP_LOG_BUFFER_HEX_LEVEL(TAG, pkt->data, pkt->data_len, ESP_LOG_WARN);
         return ESP_FAIL;
     }
 


### PR DESCRIPTION
Resolves an unsupported ctrl_typ (72) warning when the EasyTouch controller communicates with an UltraTemp or MasterTemp heater. Improved diagnostic logging that dumps the full src, dst, and payload on unknown ctrl_typ. Confirmed the packets are A5-protocol heater mode commands (action 0x72) and responses (action 0x73) exchanged between the controller (0x10) and heater address group (0x7x). Added HEATER_BASE/HEATER_ID_MASK address constants and is_heater() predicate to datalink_addr_t, HEATER_SET/HEATER_RESP enum values to datalink_ctrl_typ_t, packed structs network_heater_set_t and network_heater_resp_t matching the documented 10-byte wire format (cmd byte, mode byte 0=off/1=heat/2=cool, temp offset, unknowns), and corresponding entries in NETWORK_MSG_TYP_LIST and the poolstate_rx dispatch switch. 