### PR TITLE
Without schedules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 /hardware/**/*.kicad_prl
 /components/opnpool/__pycache__/
 /changes.txt
+/.venv/

--- a/components/opnpool/__init__.py
+++ b/components/opnpool/__init__.py
@@ -104,6 +104,10 @@ CONF_ANALOG_SENSORS = { # keys are used to overwrite sensor_id_t enum in opnpool
     "solar1_temperature": {"unit": UNIT_CELSIUS, CONF_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE, CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT},
     "solar2_temperature": {"unit": UNIT_CELSIUS, CONF_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE, CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT},
 }
+# Opt-in analog sensors: only created if the user explicitly lists them in YAML
+# (most systems lack solar sensors, and SuperFlo/IntelliFlo VS pumps never report flow).
+# Their sensor_id_t enum slots still exist; the C++ leaves the entity nullptr when unlisted.
+OPT_IN_ANALOG_SENSORS = {"solar1_temperature", "solar2_temperature", "primary_pump_flow"}
 CONF_BINARY_SENSORS = [  # used to overwrite binary_sensor_id_t enum in opnpool.h
     "primary_pump_running",
     "mode_service",
@@ -159,7 +163,8 @@ CONFIG_SCHEMA = cv.Schema({
         }) for key in CONF_SWITCHES
     },
     **{
-        cv.Optional(key, default={"name": key.replace("_", " ").title()}): sensor.sensor_schema(OpnPoolSensor).extend({
+        (cv.Optional(key) if key in OPT_IN_ANALOG_SENSORS
+         else cv.Optional(key, default={"name": key.replace("_", " ").title()})): sensor.sensor_schema(OpnPoolSensor).extend({
             cv.GenerateID(): cv.declare_id(OpnPoolSensor),
             cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=CONF_ANALOG_SENSORS[key]["unit"]): cv.string,
             cv.Optional(CONF_DEVICE_CLASS, default=CONF_ANALOG_SENSORS[key][CONF_DEVICE_CLASS]): cv.string,
@@ -316,6 +321,8 @@ async def to_code(config):
 
     # register analog sensors (constructor injection)
     for id, sensor_key in enumerate(CONF_ANALOG_SENSORS):
+        if sensor_key not in config:
+            continue  # opt-in sensor not listed -> leave its enum slot unbound (nullptr in C++)
         entity_cfg = config[sensor_key]
         if CONF_ID not in entity_cfg:
             entity_cfg[CONF_ID] = cg.new_id()

--- a/components/opnpool/__init__.py
+++ b/components/opnpool/__init__.py
@@ -34,7 +34,7 @@ import re
 import subprocess
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import climate, switch, sensor, binary_sensor, text_sensor
+from esphome.components import climate, switch, sensor, binary_sensor, text_sensor, number
 from esphome.const import (
     CONF_ID,
     CONF_DEVICE_CLASS, DEVICE_CLASS_TEMPERATURE, DEVICE_CLASS_POWER, DEVICE_CLASS_VOLUME_FLOW_RATE, DEVICE_CLASS_EMPTY,
@@ -42,8 +42,8 @@ from esphome.const import (
     CONF_STATE_CLASS, STATE_CLASS_MEASUREMENT
 )
 
-DEPENDENCIES = ["climate", "switch", "sensor", "binary_sensor", "text_sensor"]
-AUTO_LOAD = ["climate", "switch", "sensor", "binary_sensor", "text_sensor"]
+DEPENDENCIES = ["climate", "switch", "sensor", "binary_sensor", "text_sensor", "number"]
+AUTO_LOAD = ["climate", "switch", "sensor", "binary_sensor", "text_sensor", "number"]
 
 # namespace and class definitions
 opnpool_ns = cg.esphome_ns.namespace("opnpool")
@@ -53,6 +53,7 @@ OpnPoolSwitch       = opnpool_ns.class_("OpnPoolSwitch", switch.Switch, cg.Compo
 OpnPoolSensor       = opnpool_ns.class_("OpnPoolSensor", sensor.Sensor, cg.Component)
 OpnPoolBinarySensor = opnpool_ns.class_("OpnPoolBinarySensor", binary_sensor.BinarySensor, cg.Component)
 OpnPoolTextSensor   = opnpool_ns.class_("OpnPoolTextSensor", text_sensor.TextSensor, cg.Component)
+OpnPoolNumber       = opnpool_ns.class_("OpnPoolNumber", number.Number, cg.Component)
 
 CONF_RS485         = "rs485"
 CONF_RS485_RX_PIN  = "rx_pin"
@@ -91,16 +92,16 @@ CONF_SWITCHES = [  # used to overwrite switch_id_t enum in opnpool.h
     "feature4"
 ]
 CONF_ANALOG_SENSORS = { # keys are used to overwrite sensor_id_t enum in opnpool.h
-    "air_temperature":     {"unit": UNIT_CELSIUS, CONF_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE, CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT},
-    "water_temperature":   {"unit": UNIT_CELSIUS, CONF_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE, CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT},
-    "solar1_temperature":  {"unit": UNIT_CELSIUS, CONF_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE, CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT},
-    "solar2_temperature":  {"unit": UNIT_CELSIUS, CONF_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE, CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT},
-    "primary_pump_power":  {"unit": UNIT_WATT, CONF_DEVICE_CLASS: DEVICE_CLASS_POWER, CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT},
-    "primary_pump_flow":   {"unit": "gal/min", CONF_DEVICE_CLASS: DEVICE_CLASS_VOLUME_FLOW_RATE, CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT},
-    "primary_pump_speed":  {"unit": UNIT_REVOLUTIONS_PER_MINUTE, CONF_DEVICE_CLASS: DEVICE_CLASS_EMPTY, CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT},
-    "chlorinator_level":   {"unit": UNIT_PERCENT, CONF_DEVICE_CLASS: DEVICE_CLASS_EMPTY, CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT},
-    "chlorinator_salt":    {"unit": UNIT_PARTS_PER_MILLION, CONF_DEVICE_CLASS: DEVICE_CLASS_EMPTY, CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT},
+    "air_temperature":    {"unit": UNIT_CELSIUS, CONF_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE, CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT},
+    "water_temperature":  {"unit": UNIT_CELSIUS, CONF_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE, CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT},
+    "primary_pump_power": {"unit": UNIT_WATT, CONF_DEVICE_CLASS: DEVICE_CLASS_POWER, CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT},
+    "primary_pump_flow":  {"unit": "gal/min", CONF_DEVICE_CLASS: DEVICE_CLASS_VOLUME_FLOW_RATE, CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT},
+    "primary_pump_speed": {"unit": UNIT_REVOLUTIONS_PER_MINUTE, CONF_DEVICE_CLASS: DEVICE_CLASS_EMPTY, CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT},
+    "chlorinator_level":  {"unit": UNIT_PERCENT, CONF_DEVICE_CLASS: DEVICE_CLASS_EMPTY, CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT},
+    "chlorinator_salt":   {"unit": UNIT_PARTS_PER_MILLION, CONF_DEVICE_CLASS: DEVICE_CLASS_EMPTY, CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT},
     "primary_pump_error":  {"unit": UNIT_EMPTY, CONF_DEVICE_CLASS: DEVICE_CLASS_EMPTY, CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT},
+    "solar1_temperature": {"unit": UNIT_CELSIUS, CONF_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE, CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT},
+    "solar2_temperature": {"unit": UNIT_CELSIUS, CONF_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE, CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT},
 }
 CONF_BINARY_SENSORS = [  # used to overwrite binary_sensor_id_t enum in opnpool.h
     "primary_pump_running",
@@ -109,6 +110,10 @@ CONF_BINARY_SENSORS = [  # used to overwrite binary_sensor_id_t enum in opnpool.
     "mode_freeze_protection",
     "mode_timeout"
 ]
+CONF_NUMBERS = {  # used to overwrite number_id_t enum in opnpool.h
+    "primary_pump_speed_setpoint": {"min": 450.0, "max": 3450.0, "step": 1.0, "unit": UNIT_REVOLUTIONS_PER_MINUTE},
+    "chlorinator_setpoint":        {"min": 0.0,   "max": 100.0,  "step": 1.0, "unit": UNIT_PERCENT},
+}
 CONF_TEXT_SENSORS = [  # used to overwrite text_sensor_id_t enum in opnpool.h
     "pool_sched",
     "spa_sched",
@@ -164,6 +169,11 @@ CONFIG_SCHEMA = cv.Schema({
         cv.Optional(key, default={"name": key.replace("_", " ").title()}): text_sensor.text_sensor_schema(OpnPoolTextSensor).extend({
             cv.GenerateID(): cv.declare_id(OpnPoolTextSensor)
         }) for key in CONF_TEXT_SENSORS
+    },
+    **{
+        cv.Optional(key, default={"name": key.replace("_", " ").title()}): number.number_schema(OpnPoolNumber).extend({
+            cv.GenerateID(): cv.declare_id(OpnPoolNumber),
+        }) for key in CONF_NUMBERS
     },
 }).extend(cv.COMPONENT_SCHEMA)
 
@@ -321,6 +331,21 @@ async def to_code(config):
         await text_sensor.register_text_sensor(ts_entity, entity_cfg)
         cg.add(getattr(var, f"set_{text_sensor_key}_text_sensor")(ts_entity))
 
+    # register number entities (constructor injection)
+    for id, number_key in enumerate(CONF_NUMBERS):
+        entity_cfg = config[number_key]
+        if CONF_ID not in entity_cfg:
+            entity_cfg[CONF_ID] = cg.new_id()
+        num_entity = cg.new_Pvariable(entity_cfg[CONF_ID], var, id)
+        await cg.register_component(num_entity, entity_cfg)
+        await number.register_number(
+            num_entity, entity_cfg,
+            min_value=CONF_NUMBERS[number_key]["min"],
+            max_value=CONF_NUMBERS[number_key]["max"],
+            step=CONF_NUMBERS[number_key]["step"],
+        )
+        cg.add(getattr(var, f"set_{number_key}_number")(num_entity))
+
 # replace the enums in opnpool_ids.h to keep them consistent with CONF_* in this file
 
 ENTITY_ENUMS = {
@@ -329,6 +354,7 @@ ENTITY_ENUMS = {
     "sensor_id_t":        CONF_ANALOG_SENSORS,
     "binary_sensor_id_t": CONF_BINARY_SENSORS,
     "text_sensor_id_t":   CONF_TEXT_SENSORS,
+    "number_id_t":        CONF_NUMBERS,
 }
 
 def generate_enum(enum_name, items):

--- a/components/opnpool/__init__.py
+++ b/components/opnpool/__init__.py
@@ -34,7 +34,7 @@ import re
 import subprocess
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import climate, switch, sensor, binary_sensor, text_sensor, number
+from esphome.components import climate, switch, sensor, binary_sensor, text_sensor, number, select
 from esphome.const import (
     CONF_ID,
     CONF_DEVICE_CLASS, DEVICE_CLASS_TEMPERATURE, DEVICE_CLASS_POWER, DEVICE_CLASS_VOLUME_FLOW_RATE, DEVICE_CLASS_EMPTY,
@@ -42,8 +42,8 @@ from esphome.const import (
     CONF_STATE_CLASS, STATE_CLASS_MEASUREMENT
 )
 
-DEPENDENCIES = ["climate", "switch", "sensor", "binary_sensor", "text_sensor", "number"]
-AUTO_LOAD = ["climate", "switch", "sensor", "binary_sensor", "text_sensor", "number"]
+DEPENDENCIES = ["climate", "switch", "sensor", "binary_sensor", "text_sensor", "number", "select"]
+AUTO_LOAD = ["climate", "switch", "sensor", "binary_sensor", "text_sensor", "number", "select"]
 
 # namespace and class definitions
 opnpool_ns = cg.esphome_ns.namespace("opnpool")
@@ -54,6 +54,7 @@ OpnPoolSensor       = opnpool_ns.class_("OpnPoolSensor", sensor.Sensor, cg.Compo
 OpnPoolBinarySensor = opnpool_ns.class_("OpnPoolBinarySensor", binary_sensor.BinarySensor, cg.Component)
 OpnPoolTextSensor   = opnpool_ns.class_("OpnPoolTextSensor", text_sensor.TextSensor, cg.Component)
 OpnPoolNumber       = opnpool_ns.class_("OpnPoolNumber", number.Number, cg.Component)
+OpnPoolSelect       = opnpool_ns.class_("OpnPoolSelect", select.Select, cg.Component)
 
 CONF_RS485         = "rs485"
 CONF_RS485_RX_PIN  = "rx_pin"
@@ -113,6 +114,10 @@ CONF_BINARY_SENSORS = [  # used to overwrite binary_sensor_id_t enum in opnpool.
 CONF_NUMBERS = {  # used to overwrite number_id_t enum in opnpool.h
     "primary_pump_speed_setpoint": {"min": 450.0, "max": 3450.0, "step": 1.0, "unit": UNIT_REVOLUTIONS_PER_MINUTE},
     "chlorinator_setpoint":        {"min": 0.0,   "max": 100.0,  "step": 1.0, "unit": UNIT_PERCENT},
+}
+CONF_SELECTS = {  # used to overwrite select_id_t enum in opnpool.h
+    "light_color": ["Party", "Romance", "Caribbean", "American", "Sunset", "Royal",
+                    "Blue", "Green", "Red", "White", "Magenta"],
 }
 CONF_TEXT_SENSORS = [  # used to overwrite text_sensor_id_t enum in opnpool.h
     "pool_sched",
@@ -174,6 +179,11 @@ CONFIG_SCHEMA = cv.Schema({
         cv.Optional(key, default={"name": key.replace("_", " ").title()}): number.number_schema(OpnPoolNumber).extend({
             cv.GenerateID(): cv.declare_id(OpnPoolNumber),
         }) for key in CONF_NUMBERS
+    },
+    **{
+        cv.Optional(key, default={"name": key.replace("_", " ").title()}): select.select_schema(OpnPoolSelect).extend({
+            cv.GenerateID(): cv.declare_id(OpnPoolSelect),
+        }) for key in CONF_SELECTS
     },
 }).extend(cv.COMPONENT_SCHEMA)
 
@@ -346,6 +356,16 @@ async def to_code(config):
         )
         cg.add(getattr(var, f"set_{number_key}_number")(num_entity))
 
+    # register select entities (constructor injection)
+    for id, select_key in enumerate(CONF_SELECTS):
+        entity_cfg = config[select_key]
+        if CONF_ID not in entity_cfg:
+            entity_cfg[CONF_ID] = cg.new_id()
+        sel_entity = cg.new_Pvariable(entity_cfg[CONF_ID], var, id)
+        await cg.register_component(sel_entity, entity_cfg)
+        await select.register_select(sel_entity, entity_cfg, options=CONF_SELECTS[select_key])
+        cg.add(getattr(var, f"set_{select_key}_select")(sel_entity))
+
 # replace the enums in opnpool_ids.h to keep them consistent with CONF_* in this file
 
 ENTITY_ENUMS = {
@@ -355,6 +375,7 @@ ENTITY_ENUMS = {
     "binary_sensor_id_t": CONF_BINARY_SENSORS,
     "text_sensor_id_t":   CONF_TEXT_SENSORS,
     "number_id_t":        CONF_NUMBERS,
+    "select_id_t":        CONF_SELECTS,
 }
 
 def generate_enum(enum_name, items):

--- a/components/opnpool/core/opnpool.cpp
+++ b/components/opnpool/core/opnpool.cpp
@@ -49,6 +49,7 @@
 #include "entities/opnpool_binary_sensor.h"
 #include "entities/opnpool_text_sensor.h"
 #include "entities/opnpool_number.h"
+#include "entities/opnpool_select.h"
 #include "opnpool_ids.h"
 #include "pool_task/network.h"
 #include "pool_task/network_msg.h"
@@ -822,6 +823,12 @@ void
 OpnPool::set_chlorinator_setpoint_number(OpnPoolNumber * const n)
 {
     this->numbers_[enum_index(number_id_t::CHLORINATOR_SETPOINT)] = n;
+}
+
+void
+OpnPool::set_light_color_select(OpnPoolSelect * const s)
+{
+    this->selects_[enum_index(select_id_t::LIGHT_COLOR)] = s;
 }
 
 void

--- a/components/opnpool/core/opnpool.cpp
+++ b/components/opnpool/core/opnpool.cpp
@@ -48,6 +48,7 @@
 #include "entities/opnpool_sensor.h"
 #include "entities/opnpool_binary_sensor.h"
 #include "entities/opnpool_text_sensor.h"
+#include "entities/opnpool_number.h"
 #include "opnpool_ids.h"
 #include "pool_task/network.h"
 #include "pool_task/network_msg.h"
@@ -185,9 +186,9 @@ _publish_date_and_time_if(OpnPoolTextSensor * const sensor, poolstate_tod_t cons
 static void
 _publish_version_if(OpnPoolTextSensor * const sensor, poolstate_system_t const * const system)
 {
-    if (sensor != nullptr && system != nullptr && system->addr.valid && system->version.valid) {
-        static char fw_str[18];  // 2.80\0
-        snprintf(fw_str, sizeof(fw_str), "%s %d.%d", system->addr.value.to_str(), system->version.major, system->version.minor);
+    if (sensor != nullptr && system != nullptr && system->version.valid) {
+        static char fw_str[24];  // "Easy/Sun Touch 99.999\0"
+        snprintf(fw_str, sizeof(fw_str), "Easy/Sun Touch %d.%03d", system->version.major, system->version.minor);
         sensor->publish_value_if_changed(fw_str);
     }
 }
@@ -390,6 +391,7 @@ OpnPool::loop() {
                 this->update_text_sensors(&new_state);
                 this->update_analog_sensors(&new_state);
                 this->update_binary_sensors(&new_state);
+                this->update_numbers(&new_state);
             }
  
             ESP_LOGVV(TAG, "FYI Poolstate changed");
@@ -578,9 +580,10 @@ OpnPool::update_analog_sensors(poolstate_t const * const state)
         state->chlor.level
     );
     _publish_if(
-        this->sensors_[enum_index(sensor_id_t::CHLORINATOR_SALT)],  
+        this->sensors_[enum_index(sensor_id_t::CHLORINATOR_SALT)],
         state->chlor.salt
     );
+
 }
 
 /**
@@ -599,6 +602,27 @@ OpnPool::update_binary_sensors(poolstate_t const * const state)
     _publish_modes_if(
         this->binary_sensors_,
         state->system.modes);
+}
+
+/**
+ * @brief Updates number entities with current pool state.
+ *
+ * @param[in] state Pointer to the current pool state.
+ */
+void
+OpnPool::update_numbers(poolstate_t const * const state)
+{
+    OpnPoolNumber * const speed_number = this->numbers_[enum_index(number_id_t::PRIMARY_PUMP_SPEED_SETPOINT)];
+    auto const & speed = state->pumps[enum_index(datalink_pump_id_t::PRIMARY)].speed;
+    if (speed_number != nullptr && speed.valid) {
+        speed_number->publish_value_if_changed(static_cast<float>(speed.value));
+    }
+
+    OpnPoolNumber * const chlor_number = this->numbers_[enum_index(number_id_t::CHLORINATOR_SETPOINT)];
+    auto const & chlor_level = state->chlor.level;
+    if (chlor_number != nullptr && chlor_level.valid) {
+        chlor_number->publish_value_if_changed(static_cast<float>(chlor_level.value));
+    }
 }
 
 /**
@@ -786,6 +810,18 @@ void
 OpnPool::set_chlorinator_salt_sensor(OpnPoolSensor * const s)
 { 
     this->sensors_[enum_index(sensor_id_t::CHLORINATOR_SALT)] = s; 
+}
+
+void
+OpnPool::set_primary_pump_speed_setpoint_number(OpnPoolNumber * const n)
+{
+    this->numbers_[enum_index(number_id_t::PRIMARY_PUMP_SPEED_SETPOINT)] = n;
+}
+
+void
+OpnPool::set_chlorinator_setpoint_number(OpnPoolNumber * const n)
+{
+    this->numbers_[enum_index(number_id_t::CHLORINATOR_SETPOINT)] = n;
 }
 
 void

--- a/components/opnpool/core/opnpool.h
+++ b/components/opnpool/core/opnpool.h
@@ -46,6 +46,7 @@ class OpnPoolSensor;
 class OpnPoolBinarySensor;
 class OpnPoolTextSensor;
 class OpnPoolNumber;
+class OpnPoolSelect;
 
 /// @brief RS-485 GPIO pin configuration.
 struct rs485_pins_t {
@@ -111,6 +112,9 @@ class OpnPool : public Component {
     void set_primary_pump_speed_setpoint_number(OpnPoolNumber * const n);
     void set_chlorinator_setpoint_number(OpnPoolNumber * const n);
 
+    // ========== Select Setters ==========
+    void set_light_color_select(OpnPoolSelect * const s);
+
     // ========== Text Sensor Setters ==========
     void set_pool_sched_text_sensor(OpnPoolTextSensor * const ts);
     void set_spa_sched_text_sensor(OpnPoolTextSensor * const ts);
@@ -163,6 +167,7 @@ class OpnPool : public Component {
     OpnPoolBinarySensor * binary_sensors_[enum_count<binary_sensor_id_t>()]{nullptr}; ///< Binary sensor pointers.
     OpnPoolTextSensor * text_sensors_[enum_count<text_sensor_id_t>()]{nullptr};   ///< Text sensor pointers.
     OpnPoolNumber * numbers_[enum_count<number_id_t>()]{nullptr};                 ///< Number entity pointers.
+    OpnPoolSelect * selects_[enum_count<select_id_t>()]{nullptr};                 ///< Select entity pointers.
 
 #ifdef USE_MATTER
     // ========== Matter Integration ==========

--- a/components/opnpool/core/opnpool.h
+++ b/components/opnpool/core/opnpool.h
@@ -45,6 +45,7 @@ class OpnPoolSwitch;
 class OpnPoolSensor;
 class OpnPoolBinarySensor;
 class OpnPoolTextSensor;
+class OpnPoolNumber;
 
 /// @brief RS-485 GPIO pin configuration.
 struct rs485_pins_t {
@@ -106,6 +107,10 @@ class OpnPool : public Component {
     void set_mode_freeze_protection_binary_sensor(OpnPoolBinarySensor * const bs);
     void set_mode_timeout_binary_sensor(OpnPoolBinarySensor * const bs);
 
+    // ========== Number Setters ==========
+    void set_primary_pump_speed_setpoint_number(OpnPoolNumber * const n);
+    void set_chlorinator_setpoint_number(OpnPoolNumber * const n);
+
     // ========== Text Sensor Setters ==========
     void set_pool_sched_text_sensor(OpnPoolTextSensor * const ts);
     void set_spa_sched_text_sensor(OpnPoolTextSensor * const ts);
@@ -137,6 +142,7 @@ class OpnPool : public Component {
     void update_text_sensors(poolstate_t const * const state);
     void update_analog_sensors(poolstate_t const * const state);
     void update_binary_sensors(poolstate_t const * const state);
+    void update_numbers(poolstate_t const * const state);
     void update_all(poolstate_t const * const state);
 
     // ========== Accessors ==========
@@ -156,6 +162,7 @@ class OpnPool : public Component {
     OpnPoolSensor * sensors_[enum_count<sensor_id_t>()]{nullptr};                 ///< Sensor entity pointers.
     OpnPoolBinarySensor * binary_sensors_[enum_count<binary_sensor_id_t>()]{nullptr}; ///< Binary sensor pointers.
     OpnPoolTextSensor * text_sensors_[enum_count<text_sensor_id_t>()]{nullptr};   ///< Text sensor pointers.
+    OpnPoolNumber * numbers_[enum_count<number_id_t>()]{nullptr};                 ///< Number entity pointers.
 
 #ifdef USE_MATTER
     // ========== Matter Integration ==========

--- a/components/opnpool/core/opnpool_ids.h
+++ b/components/opnpool/core/opnpool_ids.h
@@ -51,16 +51,16 @@ enum class switch_id_t : uint8_t {
 
     /// @brief Sensor entity identifiers for pool measurements.
 enum class sensor_id_t : uint8_t {
-    AIR_TEMPERATURE     = 0,  ///< Ambient air temperature sensor.
-    WATER_TEMPERATURE   = 1,  ///< Pool/spa water temperature sensor.
-    SOLAR1_TEMPERATURE  = 2,  ///< Solar1 water temperature sensor.
-    SOLAR2_TEMPERATURE  = 3,  ///< Solar1 water temperature sensor.
-    PRIMARY_PUMP_POWER  = 4,  ///< Primary pump power consumption sensor.
-    PRIMARY_PUMP_FLOW   = 5,  ///< Primary pump flow rate sensor.
-    PRIMARY_PUMP_SPEED  = 6,  ///< Primary pump speed (RPM) sensor.
-    CHLORINATOR_LEVEL   = 7,  ///< Chlorinator output level sensor.
-    CHLORINATOR_SALT    = 8,  ///< Chlorinator salt level sensor.
-    PRIMARY_PUMP_ERROR  = 9   ///< Primary pump error code sensor.
+    AIR_TEMPERATURE      = 0,  ///< Ambient air temperature sensor.
+    WATER_TEMPERATURE    = 1,  ///< Pool/spa water temperature sensor.
+    PRIMARY_PUMP_POWER   = 2,  ///< Primary pump power consumption sensor.
+    PRIMARY_PUMP_FLOW    = 3,  ///< Primary pump flow rate sensor.
+    PRIMARY_PUMP_SPEED   = 4,  ///< Primary pump speed (RPM) sensor.
+    CHLORINATOR_LEVEL    = 5,  ///< Chlorinator output level sensor.
+    CHLORINATOR_SALT     = 6,  ///< Chlorinator salt level sensor.
+    PRIMARY_PUMP_ERROR   = 7,  ///< Primary pump error code sensor.
+    SOLAR1_TEMPERATURE   = 8,  ///< Solar sensor 1 temperature.
+    SOLAR2_TEMPERATURE   = 9   ///< Solar sensor 2 temperature.
 };
 
     /// @brief Binary sensor entity identifiers for pool status indicators.
@@ -70,6 +70,12 @@ enum class binary_sensor_id_t : uint8_t {
     MODE_TEMPERATURE_INC   = 2,  ///< Temperature increase mode indicator.
     MODE_FREEZE_PROTECTION = 3,  ///< Freeze protection mode active indicator.
     MODE_TIMEOUT           = 4   ///< Timeout mode active indicator.
+};
+
+    /// @brief Number entity identifiers for pool numeric controls.
+enum class number_id_t : uint8_t {
+    PRIMARY_PUMP_SPEED_SETPOINT = 0,  ///< Primary pump speed setpoint (RPM).
+    CHLORINATOR_SETPOINT        = 1,  ///< Chlorinator output level setpoint (%).
 };
 
     /// @brief Text sensor entity identifiers for pool status strings.

--- a/components/opnpool/core/opnpool_ids.h
+++ b/components/opnpool/core/opnpool_ids.h
@@ -78,6 +78,11 @@ enum class number_id_t : uint8_t {
     CHLORINATOR_SETPOINT        = 1,  ///< Chlorinator output level setpoint (%).
 };
 
+    /// @brief Select entity identifiers for pool dropdown controls.
+enum class select_id_t : uint8_t {
+    LIGHT_COLOR = 0,  ///< Light color/show mode select.
+};
+
     /// @brief Text sensor entity identifiers for pool status strings.
 enum class text_sensor_id_t : uint8_t {
     POOL_SCHED          = 0,  ///< Pool schedule information.

--- a/components/opnpool/core/poolstate.h
+++ b/components/opnpool/core/poolstate.h
@@ -181,8 +181,8 @@ struct poolstate_sched_t {
 enum class poolstate_temp_typ_t : uint8_t {
     AIR     = 0,  ///< Air temperature sensor.
     WATER   = 1,  ///< Water temperature sensor.
-    SOLAR_1 = 2,  ///< Solar sensor 1.
-    SOLAR_2 = 3   ///< Solar sensor 2.
+    SOLAR_1 = 2,  ///< Solar sensor 1 temperature.
+    SOLAR_2 = 3   ///< Solar sensor 2 temperature.
 };
 
 /// @}

--- a/components/opnpool/core/poolstate_rx.cpp
+++ b/components/opnpool/core/poolstate_rx.cpp
@@ -196,32 +196,21 @@ _update_system_time(cJSON * const dbg, network_ctrl_state_bcast_t const * const 
 static void
 _update_temps(cJSON * const dbg, network_ctrl_state_bcast_t const * const msg, poolstate_uint8_t * const temps)
 {
-    uint8_t const air_idx = enum_index(poolstate_temp_typ_t::AIR);
-    uint8_t const water_idx = enum_index(poolstate_temp_typ_t::WATER);
-    static_assert(air_idx < enum_count<poolstate_temp_typ_t>(), "size err for air_idx");
-    static_assert(water_idx < enum_count<poolstate_temp_typ_t>(), "size err for water_idx");
+    uint8_t const air_idx     = enum_index(poolstate_temp_typ_t::AIR);
+    uint8_t const water_idx   = enum_index(poolstate_temp_typ_t::WATER);
+    uint8_t const solar1_idx  = enum_index(poolstate_temp_typ_t::SOLAR_1);
+    uint8_t const solar2_idx  = enum_index(poolstate_temp_typ_t::SOLAR_2);
+    static_assert(air_idx    < enum_count<poolstate_temp_typ_t>(), "size err for air_idx");
+    static_assert(water_idx  < enum_count<poolstate_temp_typ_t>(), "size err for water_idx");
+    static_assert(solar1_idx < enum_count<poolstate_temp_typ_t>(), "size err for solar1_idx");
+    static_assert(solar2_idx < enum_count<poolstate_temp_typ_t>(), "size err for solar2_idx");
 
-    temps[air_idx] = {
-        .valid = true,
-        .value = msg->air_temp
-    };
-    temps[water_idx] = {
-        .valid = true,
-        .value = msg->pool_temp
-    };
+    temps[air_idx]    = { .valid = true, .value = msg->air_temp     };
+    temps[water_idx]  = { .valid = true, .value = msg->pool_temp    };
+    temps[solar1_idx] = { .valid = true, .value = msg->solar_temp_1 };
+    temps[solar2_idx] = { .valid = true, .value = msg->solar_temp_2 };
 
-    uint8_t const solar1_idx = enum_index(poolstate_temp_typ_t::SOLAR_1);
-    uint8_t const solar2_idx = enum_index(poolstate_temp_typ_t::SOLAR_2);
-    temps[solar1_idx] = {
-        .valid = true,
-        .value = msg->solar_temp_1
-    };
-    temps[solar2_idx] = {
-        .valid = true,
-        .value = msg->solar_temp_2
-    };
-
-    ESP_LOGVV(TAG, "Air %u, Spa %u, Water %u Solar1 %u, Solar2 %u", msg->air_temp, msg->spa_temp, msg->pool_temp, msg->solar_temp_1, msg->solar_temp_2);
+    ESP_LOGVV(TAG, "Air %u, Spa %u, Water %u Solar1 %u Solar2 %u", msg->air_temp, msg->spa_temp, msg->pool_temp, msg->solar_temp_1, msg->solar_temp_2);
 
     if (ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE) {
         poolstate_rx_log::add_temps(dbg, poolstate_rx_log::KEY_TEMPS, temps);
@@ -859,28 +848,25 @@ _chlor_model_req(cJSON * const dbg, network_chlor_model_req_t const * const msg)
  * @param msg   Pointer to the received network_chlor_model_resp_t message.
  * @param chlor Pointer to the poolstate_chlor_t structure to update.
  *
- * This function updates the chlorine generator name and salt level in the pool state and
- * logs the status to the debug JSON object if verbose logging is enabled.
+ * This function updates the chlorine generator name in the pool state and logs it to the
+ * debug JSON object if verbose logging is enabled. Salt is not carried by this message;
+ * it is reported by LEVEL_RESP (0x12).
  */
 static void
 _chlor_model_resp(cJSON * const dbg, network_chlor_model_resp_t const * const msg, poolstate_chlor_t * const chlor)
 {
     if (!msg || !chlor) { ESP_LOGW(TAG, "null to %s", __func__); return; }
 
-    chlor->salt = {
-        .valid = true,
-        .value = static_cast<uint16_t>(msg->salt * 50)
-    };
-
+        // this message carries only the name; the leading byte is not salt.
+        // salt is reported separately by LEVEL_RESP (0x12).
     uint32_t name_size = sizeof(chlor->name.value);
     strncpy(chlor->name.value, msg->name, name_size);
     chlor->name.value[name_size - 1] = '\0';
     chlor->name.valid = true;
 
     if (ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE) {
-        cJSON_AddNumberToObject(dbg, poolstate_rx_log::KEY_SALT, chlor->salt.value);
         cJSON_AddStringToObject(dbg, poolstate_rx_log::KEY_NAME, chlor->name.value);
-        ESP_LOGV(TAG, "Chlorine status updated: salt=%u, name=%s", chlor->salt.value, chlor->name.value);
+        ESP_LOGV(TAG, "Chlorinator name updated: name=%s", chlor->name.value);
     }
 }
 

--- a/components/opnpool/core/poolstate_rx_log.cpp
+++ b/components/opnpool/core/poolstate_rx_log.cpp
@@ -371,12 +371,8 @@ add_pump_reg_set(cJSON * const obj, char const * const key, datalink_pump_id_t c
     cJSON * const item = _create_item(obj, key);
 
     cJSON_AddStringToObject(item, KEY_ID, enum_str(pump_id));
-    cJSON_AddStringToObject(item, KEY_ADDRESS, enum_str(reg->address));
-    cJSON_AddStringToObject(item, KEY_OPERATION, reg->operation.to_str());
-
-    if (reg->operation.is_write()) {
-        cJSON_AddNumberToObject(item, KEY_VALUE, reg->value.to_uint16());
-    }
+    cJSON_AddNumberToObject(item, KEY_ADDRESS, reg->address.to_uint16());
+    cJSON_AddNumberToObject(item, KEY_VALUE, reg->value.to_uint16());
 }
 
 void

--- a/components/opnpool/entities/opnpool_climate.cpp
+++ b/components/opnpool/entities/opnpool_climate.cpp
@@ -268,7 +268,7 @@ OpnPoolClimate::control(const climate::ClimateCall &call)
     if (thermos_changed) {
 
         network_msg_t msg = {};
-        msg.src = datalink_addr_t::remote();
+        msg.src = datalink_addr_t::wireless_remote();  // 0x22 (ScreenLogic/wireless remote)
         msg.dst = controller_addr;
         msg.typ = network_msg_typ_t::CTRL_HEAT_SET;
         msg.u.a5.ctrl_heat_set.pool_set_point = thermos_new[thermo_pool_idx].set_point_in_f.value;

--- a/components/opnpool/entities/opnpool_number.cpp
+++ b/components/opnpool/entities/opnpool_number.cpp
@@ -1,0 +1,191 @@
+/**
+ * @file opnpool_number.cpp
+ * @brief Actuates pump speed from Home Assistant on the IntelliFlo VS pump.
+ *
+ * @details
+ * Implements the number entity interface for controlling a Pentair IntelliFlo
+ * variable-speed pump over RS-485.  When Home Assistant sets a new speed value
+ * the following three-message sequence is queued to the pool_task:
+ *
+ *   1. PUMP_REMOTE_CTRL_SET (0xFF) – enables external (remote) control mode.
+ *   2. PUMP_REG_SET – writes the requested RPM to register 0x02C4.
+ *   3. PUMP_RUN_SET (0x0A) – commands the pump to start/keep running.
+ *
+ * State updates flow in the opposite direction: the pool_task receives periodic
+ * PUMP_STATUS_RESP packets and the confirmed pump speed is published back to
+ * Home Assistant via publish_value_if_changed().
+ *
+ * @author bryanribas
+ * @copyright Copyright (c) 2026
+ * @license SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <esp_system.h>
+#include <esphome/core/log.h>
+
+#include "opnpool_number.h"
+#include "core/opnpool.h"
+#include "core/poolstate.h"
+#include "ipc/ipc.h"
+#include "pool_task/datalink.h"
+#include "pool_task/network_msg.h"
+#pragma GCC diagnostic error "-Wall"
+#pragma GCC diagnostic error "-Wextra"
+#pragma GCC diagnostic error "-Wunused-parameter"
+
+namespace esphome {
+namespace opnpool {
+
+constexpr char TAG[] = "opnpool_number";
+
+/**
+ * @brief Logs configuration and last known state of the number entity.
+ */
+void
+OpnPoolNumber::dump_config()
+{
+    LOG_NUMBER("  ", "Number", this);
+    ESP_LOGCONFIG(TAG, "    ID: %u  Last value: %s",
+                  static_cast<uint8_t>(id_),
+                  last_.valid ? std::to_string(static_cast<int>(last_.value)).c_str() : "Unknown");
+}
+
+/**
+ * @brief Dispatches a Home Assistant value change to the matching handler.
+ *
+ * @param[in] value Desired value (RPM for the pump speed entity, % for the chlorinator).
+ */
+void
+OpnPoolNumber::control(float value)
+{
+    if (!this->parent_) { ESP_LOGW(TAG, "Parent unknown"); return; }
+
+    switch (id_) {
+        case number_id_t::PRIMARY_PUMP_SPEED_SETPOINT:
+            this->control_pump_speed_(value);
+            break;
+        case number_id_t::CHLORINATOR_SETPOINT:
+            this->control_chlor_level_(value);
+            break;
+        default:
+            ESP_LOGW(TAG, "Unhandled number id %u", static_cast<uint8_t>(id_));
+            break;
+    }
+    // DON'T publish state here — wait for confirmation from the bus.
+}
+
+/**
+ * @brief Sends the pump speed command sequence when Home Assistant changes the value.
+ *
+ * @param[in] value Desired pump speed in RPM (450 – 3450).
+ */
+void
+OpnPoolNumber::control_pump_speed_(float value)
+{
+    PoolState * const state_class_ptr = parent_->get_opnpool_state();
+    if (!state_class_ptr) { ESP_LOGW(TAG, "Pool state unknown"); return; }
+
+    poolstate_t state;
+    state_class_ptr->get(&state);
+
+    datalink_addr_t const controller_addr = state.system.addr.value;
+    if (!controller_addr.is_controller()) {
+        ESP_LOGW(TAG, "Controller address still unknown, cannot send pump command");
+        return;
+    }
+
+    datalink_addr_t const pump_addr = datalink_addr_t::pump(datalink_pump_id_t::PRIMARY);
+    uint16_t        const rpm       = static_cast<uint16_t>(value);
+
+    // 1. Enable remote (external) control on the pump.
+    {
+        network_msg_t msg;
+        msg.src                  = controller_addr;
+        msg.dst                  = pump_addr;
+        msg.typ                  = network_msg_typ_t::PUMP_REMOTE_CTRL_SET;
+        msg.u.a5.pump_ctrl.raw   = 0xFF;
+        ipc_send_network_msg_to_pool_task(&msg, parent_->get_ipc());
+    }
+
+    // 2. Write the requested RPM to the pump's RPM register (0x02C4) via a
+    //    "set register" command (action REG, 0x01): payload {0x02, 0xC4, hi, lo}.
+    {
+        constexpr uint16_t rpm_reg = static_cast<uint16_t>(network_pump_reg_addr_t::RPM);
+
+        network_msg_t msg;
+        msg.src                        = controller_addr;
+        msg.dst                        = pump_addr;
+        msg.typ                        = network_msg_typ_t::PUMP_REG_SET;
+        msg.u.a5.pump_reg_set.address  = {
+            .high = static_cast<uint8_t>(rpm_reg >> 8),
+            .low  = static_cast<uint8_t>(rpm_reg & 0xFF)
+        };
+        msg.u.a5.pump_reg_set.value    = {
+            .high = static_cast<uint8_t>(rpm >> 8),
+            .low  = static_cast<uint8_t>(rpm & 0xFF)
+        };
+        ipc_send_network_msg_to_pool_task(&msg, parent_->get_ipc());
+    }
+
+    // 3. Command the pump to run.
+    {
+        network_msg_t msg;
+        msg.src                    = controller_addr;
+        msg.dst                    = pump_addr;
+        msg.typ                    = network_msg_typ_t::PUMP_RUN_SET;
+        msg.u.a5.pump_running.raw  = 0x0A;  // 0x0A = running
+        ipc_send_network_msg_to_pool_task(&msg, parent_->get_ipc());
+    }
+
+    ESP_LOGV(TAG, "Sent pump speed command: %u RPM", rpm);
+    // DON'T publish state here — wait for PUMP_STATUS_RESP confirmation.
+}
+
+/**
+ * @brief Sends a CHLOR_LEVEL_SET command to the IntelliChlor when Home Assistant changes the value.
+ *
+ * @details
+ * The IC protocol is addressed to the chlorinator (0x50); unlike the A5 control messages it
+ * does not require the learned controller address. The confirmed level is published back to
+ * Home Assistant from poolstate.chlor.level (updated by the echoed/broadcast CHLOR_LEVEL_SET).
+ *
+ * @param[in] value Desired chlorine output level (0–100 %).
+ */
+void
+OpnPoolNumber::control_chlor_level_(float value)
+{
+    if (value < 0.f)   value = 0.f;
+    if (value > 100.f) value = 100.f;
+
+    network_msg_t msg;
+    msg.src = datalink_addr_t::wireless_remote();  // IC frames carry no src; set for consistency
+    msg.dst = datalink_addr_t::chlorinator();      // 0x50
+    msg.typ = network_msg_typ_t::CHLOR_LEVEL_SET;
+    msg.u.ic.chlor_level_set = {
+        .level = static_cast<uint8_t>(value)
+    };
+
+    ESP_LOGV(TAG, "Sending CHLOR_LEVEL_SET: %u%%", msg.u.ic.chlor_level_set.level);
+    if (ipc_send_network_msg_to_pool_task(&msg, this->parent_->get_ipc()) != ESP_OK) {
+        ESP_LOGW(TAG, "Failed to send CHLOR_LEVEL_SET message to pool task");
+    }
+    // DON'T publish state here — wait for the chlorinator level confirmation on the bus.
+}
+
+/**
+ * @brief Publishes the pump speed to Home Assistant if it has changed.
+ *
+ * @param[in] value New pump speed in RPM, as reported by the pump.
+ */
+void
+OpnPoolNumber::publish_value_if_changed(float value)
+{
+    if (!last_.valid || last_.value != value) {
+        this->publish_state(value);
+        last_ = {.valid = true, .value = value};
+        ESP_LOGV(TAG, "Published pump speed: %.0f RPM", value);
+    }
+}
+
+}  // namespace opnpool
+}  // namespace esphome

--- a/components/opnpool/entities/opnpool_number.h
+++ b/components/opnpool/entities/opnpool_number.h
@@ -1,0 +1,97 @@
+/**
+ * @file opnpool_number.h
+ * @brief Number entity interface for OPNpool component.
+ *
+ * @details
+ * Declares the OpnPoolNumber class, which implements ESPHome's number interface
+ * for setting pool pump speed (RPM) on a Pentair IntelliFlo variable-speed pump.
+ *
+ * @author bryanribas
+ * @copyright Copyright (c) 2026
+ * @license SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <esp_system.h>
+#include <esp_types.h>
+#include <esphome/core/component.h>
+#include <esphome/components/number/number.h>
+
+#include "core/opnpool_ids.h"
+
+namespace esphome {
+namespace opnpool {
+
+// Forward declarations
+struct poolstate_t;
+class OpnPool;
+
+/**
+ * @brief Number entity for OPNpool component.
+ *
+ * @details
+ * Extends ESPHome's Number and Component classes to provide speed control over
+ * a Pentair IntelliFlo variable-speed pump. Sends a three-message command
+ * sequence (remote-control enable → VS speed set → run) to the pump via RS-485
+ * and publishes the confirmed speed from pump status responses.
+ *
+ * Valid range: 450 – 3450 RPM (IntelliFlo VS hardware limit).
+ */
+class OpnPoolNumber : public number::Number, public Component {
+  public:
+    /**
+     * @brief Constructs an OpnPoolNumber entity.
+     *
+     * @param[in] parent Pointer to the parent OpnPool component.
+     * @param[in] id     The number entity ID from number_id_t.
+     */
+    OpnPoolNumber(OpnPool * parent, uint8_t id)
+        : parent_{parent}, id_{static_cast<number_id_t>(id)} {}
+
+    /// @brief Logs configuration details at startup.
+    void dump_config();
+
+    /**
+     * @brief Publishes the pump speed to Home Assistant if it has changed.
+     *
+     * @param[in] value The new speed in RPM.
+     */
+    void publish_value_if_changed(float value);
+
+  protected:
+    /**
+     * @brief Dispatches a value change from Home Assistant to the matching handler.
+     *
+     * Routes on the entity id: pump speed (RPM) or chlorinator output level (%).
+     *
+     * @param[in] value The desired value (RPM or %, depending on the entity).
+     */
+    void control(float value) override;
+
+    /**
+     * @brief Sends the pump speed command sequence (remote-ctrl enable → VS set → run).
+     *
+     * @param[in] value The desired speed in RPM.
+     */
+    void control_pump_speed_(float value);
+
+    /**
+     * @brief Sends a CHLOR_LEVEL_SET command to the IntelliChlor chlorinator.
+     *
+     * @param[in] value The desired chlorine output level (0–100 %).
+     */
+    void control_chlor_level_(float value);
+
+    OpnPool * const   parent_;  ///< Parent OpnPool component.
+    number_id_t const id_;      ///< Number entity ID.
+
+    /// @brief Tracks the last published value to avoid redundant updates.
+    struct last_t {
+        bool  valid;
+        float value;
+    } last_{false, 0.f};
+};
+
+}  // namespace opnpool
+}  // namespace esphome

--- a/components/opnpool/entities/opnpool_select.cpp
+++ b/components/opnpool/entities/opnpool_select.cpp
@@ -1,0 +1,120 @@
+/**
+ * @file opnpool_select.cpp
+ * @brief Actuates light color mode from Home Assistant on the pool controller.
+ *
+ * @details
+ * Implements the select entity interface for controlling Pentair IntelliBrite
+ * light color/show modes over RS-485. Sends a LIGHT_COLOR_SET (0x60) command
+ * with a 2-byte payload [color_byte, 0x00] to the EasyTouch controller when
+ * a mode is selected in Home Assistant.
+ *
+ * @author bryanribas
+ * @copyright Copyright (c) 2026
+ * @license SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <esp_system.h>
+#include <esphome/core/log.h>
+
+#include "opnpool_select.h"
+#include "core/opnpool.h"
+#include "core/poolstate.h"
+#include "ipc/ipc.h"
+#include "pool_task/datalink.h"
+#include "pool_task/network_msg.h"
+#pragma GCC diagnostic error "-Wall"
+#pragma GCC diagnostic error "-Wextra"
+#pragma GCC diagnostic error "-Wunused-parameter"
+
+namespace esphome {
+namespace opnpool {
+
+constexpr char TAG[] = "opnpool_select";
+
+/// @brief Maps option name strings to their EasyTouch color byte values.
+struct color_entry_t {
+    const char * name;
+    uint8_t      value;
+};
+
+static constexpr color_entry_t COLOR_TABLE[] = {
+    {"Party",     0xB1},
+    {"Romance",   0xB2},
+    {"Caribbean", 0xB3},
+    {"American",  0xB4},
+    {"Sunset",    0xB5},
+    {"Royal",     0xB6},
+    {"Blue",      0xC1},
+    {"Green",     0xC2},
+    {"Red",       0xC3},
+    {"White",     0xC4},
+    {"Magenta",   0xC5},
+};
+
+/**
+ * @brief Logs configuration details at startup.
+ */
+void
+OpnPoolSelect::dump_config()
+{
+    LOG_SELECT("  ", "Select", this);
+    ESP_LOGCONFIG(TAG, "    ID: %u", static_cast<uint8_t>(id_));
+}
+
+/**
+ * @brief Sends a LIGHT_COLOR_SET command when the user picks a color mode.
+ *
+ * @param[in] value The selected option string (e.g. "Blue", "Party").
+ */
+void
+OpnPoolSelect::control(const std::string &value)
+{
+    if (!this->parent_) { ESP_LOGW(TAG, "Parent unknown"); return; }
+
+    PoolState * const state_class_ptr = parent_->get_opnpool_state();
+    if (!state_class_ptr) { ESP_LOGW(TAG, "Pool state unknown"); return; }
+
+    poolstate_t state;
+    state_class_ptr->get(&state);
+
+    datalink_addr_t const controller_addr = state.system.addr.value;
+    if (!controller_addr.is_controller()) {
+        ESP_LOGW(TAG, "Controller address still unknown, cannot send light color command");
+        return;
+    }
+
+    // look up color byte for the selected option name
+    uint8_t color_byte = 0;
+    bool found = false;
+    for (auto const &entry : COLOR_TABLE) {
+        if (value == entry.name) {
+            color_byte = entry.value;
+            found = true;
+            break;
+        }
+    }
+    if (!found) {
+        ESP_LOGW(TAG, "Unknown light color option: %s", value.c_str());
+        return;
+    }
+
+    network_msg_t msg;
+    msg.src = datalink_addr_t::wireless_remote();  // 0x22
+    msg.dst = controller_addr;
+    msg.typ = network_msg_typ_t::CTRL_LIGHT_COLOR_SET;
+    msg.u.a5.ctrl_light_color_set = {
+        .color   = color_byte,
+        .padding = 0x00
+    };
+
+    ESP_LOGV(TAG, "Sending LIGHT_COLOR_SET: %s (0x%02X) dst=0x%02X", value.c_str(), color_byte, controller_addr.addr);
+    if (ipc_send_network_msg_to_pool_task(&msg, this->parent_->get_ipc()) != ESP_OK) {
+        ESP_LOGW(TAG, "Failed to send LIGHT_COLOR_SET message to pool task");
+        return;
+    }
+
+    this->publish_state(value);
+}
+
+}  // namespace opnpool
+}  // namespace esphome

--- a/components/opnpool/entities/opnpool_select.h
+++ b/components/opnpool/entities/opnpool_select.h
@@ -1,0 +1,70 @@
+/**
+ * @file opnpool_select.h
+ * @brief Select entity interface for OPNpool component.
+ *
+ * @details
+ * Declares the OpnPoolSelect class, which implements ESPHome's select interface
+ * for choosing the IntelliBrite light color/show mode on a Pentair EasyTouch
+ * controller. Sends a 0x60 (LIGHT_COLOR_SET) command to the controller when
+ * the user picks a mode in Home Assistant.
+ *
+ * @author bryanribas
+ * @copyright Copyright (c) 2026
+ * @license SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <esp_system.h>
+#include <esp_types.h>
+#include <esphome/core/component.h>
+#include <esphome/components/select/select.h>
+
+#include "core/opnpool_ids.h"
+
+namespace esphome {
+namespace opnpool {
+
+// Forward declarations
+class OpnPool;
+
+/**
+ * @brief Select entity for OPNpool light color mode.
+ *
+ * @details
+ * Extends ESPHome's Select and Component classes to control IntelliBrite
+ * light color/show modes via the Pentair EasyTouch RS-485 protocol. When
+ * a color mode is selected in Home Assistant, a LIGHT_COLOR_SET (0x60)
+ * command is sent to the controller with the corresponding color byte.
+ */
+class OpnPoolSelect : public select::Select, public Component {
+  public:
+    /**
+     * @brief Constructs an OpnPoolSelect entity.
+     *
+     * @param[in] parent Pointer to the parent OpnPool component.
+     * @param[in] id     The select entity ID from select_id_t.
+     */
+    OpnPoolSelect(OpnPool * parent, uint8_t id)
+        : parent_{parent}, id_{static_cast<select_id_t>(id)} {}
+
+    /// @brief Logs configuration details at startup.
+    void dump_config();
+
+  protected:
+    /**
+     * @brief Handles color mode selection from Home Assistant.
+     *
+     * Sends CTRL_LIGHT_COLOR_SET to the pool controller with the
+     * color byte corresponding to the selected option name.
+     *
+     * @param[in] value The selected option string (e.g. "Blue", "Party").
+     */
+    void control(const std::string &value) override;
+
+    OpnPool * const   parent_;  ///< Parent OpnPool component.
+    select_id_t const id_;      ///< Select entity ID.
+};
+
+}  // namespace opnpool
+}  // namespace esphome

--- a/components/opnpool/entities/opnpool_switch.cpp
+++ b/components/opnpool/entities/opnpool_switch.cpp
@@ -94,7 +94,7 @@ OpnPoolSwitch::write_state(bool value)
     uint8_t const circuit_idx = enum_index(circuit);
 
     network_msg_t msg;
-    msg.src = datalink_addr_t::remote();
+    msg.src = datalink_addr_t::wireless_remote();  // 0x22 (ScreenLogic/wireless remote)
     msg.dst = controller_addr;
     msg.typ = network_msg_typ_t::CTRL_CIRCUIT_SET;
     msg.u.a5 = {
@@ -104,7 +104,7 @@ OpnPoolSwitch::write_state(bool value)
         }
     };
 
-    ESP_LOGVV(TAG, "Sending CIRCUIT_SET command: circuit+1=%u to %u", msg.u.a5.ctrl_circuit_set.circuit_plus_1, msg.u.ctrl_circuit_set.value);
+    ESP_LOGV(TAG, "Sending CIRCUIT_SET: circuit+1=%u value=%u src=0x%02X dst=0x%02X", msg.u.a5.ctrl_circuit_set.circuit_plus_1, msg.u.a5.ctrl_circuit_set.value, msg.src.addr, msg.dst.addr);
     if (ipc_send_network_msg_to_pool_task(&msg, this->parent_->get_ipc()) != ESP_OK) {
         ESP_LOGW(TAG, "Failed to send CIRCUIT_SET message to pool task");
     }

--- a/components/opnpool/opnpool_number.h
+++ b/components/opnpool/opnpool_number.h
@@ -1,0 +1,3 @@
+/** @file opnpool_number.h - Forwarding header for ESPHome code generation. */
+#pragma once
+#include "entities/opnpool_number.h"

--- a/components/opnpool/opnpool_select.h
+++ b/components/opnpool/opnpool_select.h
@@ -1,0 +1,3 @@
+/** @file opnpool_select.h - Forwarding header for ESPHome code generation. */
+#pragma once
+#include "entities/opnpool_select.h"

--- a/components/opnpool/pool_task/datalink.h
+++ b/components/opnpool/pool_task/datalink.h
@@ -83,6 +83,7 @@ struct datalink_addr_t {
     static constexpr datalink_addr_t remote()               { return datalink_addr_t{REMOTE}; }
     static constexpr datalink_addr_t wireless_remote()      { return datalink_addr_t{WIRELESS_REMOTE}; }
     static constexpr datalink_addr_t quicktouch_remote()    { return datalink_addr_t{QUICKTOUCH_REMOTE}; }
+    static constexpr datalink_addr_t chlorinator()          { return datalink_addr_t{CHLORINATOR}; }
 
     static constexpr datalink_addr_t pump(datalink_pump_id_t const pump_id) { 
         return datalink_addr_t{ static_cast<uint8_t>(PUMP_BASE | (static_cast<uint8_t>(pump_id) & PUMP_ID_MASK)) };
@@ -94,8 +95,9 @@ struct datalink_addr_t {
     constexpr bool is_pump()        const { return (addr & 0xF0) == PUMP_BASE; }
     constexpr bool is_heater()      const { return (addr & 0xF0) == HEATER_BASE; }
     constexpr bool is_unknown_90()  const { return addr == UNKNOWN_90; }
-    constexpr bool is_chlorinator() const { return addr == CHLORINATOR; } 
+    constexpr bool is_chlorinator() const { return addr == CHLORINATOR; }
     constexpr bool is_broadcast()   const { return addr == BROADCAST; }
+    constexpr bool is_all()         const { return addr == ALL; }  ///< IC responses to the controller use dst 0x00
     constexpr char const * to_str() const { return addr == SUNTOUCH_CONTROLLER  ? "Suntouch" :
                                                    addr == EASYTOUCH_CONTROLLER ? "EasyTouch" : "unknown"; }
 

--- a/components/opnpool/pool_task/datalink_pkt.h
+++ b/components/opnpool/pool_task/datalink_pkt.h
@@ -68,6 +68,7 @@ enum class datalink_ctrl_typ_t : uint8_t {
     TIME_REQ         = 0xC5,
     CIRCUIT_RESP     = 0x06,
     CIRCUIT_SET      = 0x86,
+    LIGHT_COLOR_SET  = 0x60,  ///< Set light color/show mode (ScreenLogic command)
     CIRCUIT_REQ      = 0xC6,
     HEAT_RESP        = 0x08,
     HEAT_SET         = 0x88,

--- a/components/opnpool/pool_task/datalink_pkt.h
+++ b/components/opnpool/pool_task/datalink_pkt.h
@@ -210,6 +210,7 @@ struct datalink_pkt_t {
     datalink_typ_t     typ;       ///< Message type from datalink_hdr_a5->typ.
     datalink_addr_t    src;       ///< Source address from datalink_hdr_a5->src.
     datalink_addr_t    dst;       ///< Destination address from datalink_hdr_a5->dst.
+    uint8_t            ver;       ///< A5 protocol version byte (e.g. 0x01=EasyTouch, 0x31=SunTouch).
     datalink_data_t *  data;      ///< Pointer to the data payload buffer.
     size_t             data_len;  ///< Length of the data payload.
     skb_handle_t       skb;       ///< Handle to the socket buffer containing the packet data.

--- a/components/opnpool/pool_task/datalink_rx.cpp
+++ b/components/opnpool/pool_task/datalink_rx.cpp
@@ -264,6 +264,7 @@ _read_head(rs485_handle_t const rs485, local_data_t * const local, datalink_pkt_
                 if ( hdr->src.is_pump() || hdr->dst.is_pump() ) {
                     pkt->prot = datalink_prot_t::A5_PUMP;
                 }
+                pkt->ver      = hdr->ver;
                 pkt->typ.raw  = hdr->typ;
                 pkt->src      = hdr->src;
                 pkt->dst      = hdr->dst;

--- a/components/opnpool/pool_task/datalink_tx.cpp
+++ b/components/opnpool/pool_task/datalink_tx.cpp
@@ -44,7 +44,7 @@ constexpr size_t DBG_SIZE = 128;
 constexpr size_t DATALINK_PREAMBLE_IC_SIZE = sizeof(datalink_preamble_ic);
 constexpr size_t DATALINK_PREAMBLE_A5_SIZE = sizeof(datalink_preamble_a5);
 
-constexpr uint8_t A5_PROTOCOL_VERSION = 0x01;
+// A5_PROTOCOL_VERSION is now taken from datalink_pkt_t::ver (learned from controller broadcasts)
 
 /**
  * @brief          Fills the IC protocol packet header fields for transmission.
@@ -53,15 +53,16 @@ constexpr uint8_t A5_PROTOCOL_VERSION = 0x01;
  * @param[in]  typ  Message type union for the packet.
  */
 static void
-_enter_ic_head(datalink_head_ic_t * const head, datalink_typ_t const typ)
+_enter_ic_head(datalink_head_ic_t * const head, datalink_addr_t const dst, datalink_typ_t const typ)
 {
     head->ff = 0xFF;
     for (uint_least8_t ii = 0; ii < DATALINK_PREAMBLE_IC_SIZE; ii++) {
         head->preamble[ii] = datalink_preamble_ic[ii];
     }
 
-        // 2BD: we know the address of the controller from the broadcast.  use that.
-    head->hdr.dst = datalink_addr_t::suntouch_controller();
+        // address the frame to its intended destination (e.g. the chlorinator for a
+        // CHLOR_LEVEL_SET). Falls back to the controller when no destination was set.
+    head->hdr.dst = dst.addr ? dst : datalink_addr_t::suntouch_controller();
     head->hdr.typ = typ.raw;
 }
 
@@ -86,13 +87,13 @@ _enter_ic_tail(datalink_tail_ic_t * const tail, uint8_t const * const start, uin
  * @param[in]  data_len Length of the data payload.
  */
 static void
-_enter_a5_head(datalink_head_a5_t * const head, datalink_addr_t const src, datalink_addr_t const dst, datalink_typ_t const typ, size_t const data_len)
+_enter_a5_head(datalink_head_a5_t * const head, datalink_addr_t const src, datalink_addr_t const dst, datalink_typ_t const typ, size_t const data_len, uint8_t const ver)
 {
     head->ff = 0xFF;
     for (uint_least8_t ii = 0; ii < DATALINK_PREAMBLE_A5_SIZE; ii++) {
         head->preamble[ii] = datalink_preamble_a5[ii];
     }
-    head->hdr.ver = A5_PROTOCOL_VERSION;
+    head->hdr.ver = ver;
     head->hdr.src = src;
     head->hdr.dst = dst;
     head->hdr.typ = typ.raw;
@@ -135,7 +136,7 @@ datalink_tx_pkt_queue(rs485_handle_t const rs485, datalink_pkt_t const * const p
     switch (pkt->prot) {
         case datalink_prot_t::IC: {
             datalink_head_ic_t * const head = (datalink_head_ic_t *) skb_push(skb, sizeof(datalink_head_ic_t));
-            _enter_ic_head(head, pkt->typ);
+            _enter_ic_head(head, pkt->dst, pkt->typ);
 
             uint8_t * checksum_start = head->preamble;
             uint8_t * checksum_stop = skb->priv.tail;
@@ -146,7 +147,7 @@ datalink_tx_pkt_queue(rs485_handle_t const rs485, datalink_pkt_t const * const p
         case datalink_prot_t::A5_CTRL:
         case datalink_prot_t::A5_PUMP: {
             datalink_head_a5_t * const head = (datalink_head_a5_t *) skb_push(skb, sizeof(datalink_head_a5_t));
-            _enter_a5_head(head, pkt->src, pkt->dst, pkt->typ, pkt->data_len);
+            _enter_a5_head(head, pkt->src, pkt->dst, pkt->typ, pkt->data_len, pkt->ver);
 
             uint8_t * checksum_start = head->preamble + DATALINK_PREAMBLE_A5_SIZE - 1;
             uint8_t * checksum_stop = skb->priv.tail;

--- a/components/opnpool/pool_task/network_create.cpp
+++ b/components/opnpool/pool_task/network_create.cpp
@@ -64,6 +64,7 @@ network_create_pkt(network_msg_t const * const msg, datalink_pkt_t * const pkt)
     pkt->dst      = msg->dst;
     pkt->prot     = info->proto;
     pkt->typ      = info->datalink_typ;
+    pkt->ver      = 0x01;  // default; overridden by pool_task with learned controller version
     pkt->data_len = data_len;
     pkt->skb      = skb_alloc(DATALINK_MAX_HEAD_SIZE + data_len + DATALINK_MAX_TAIL_SIZE);
     if (!pkt->skb) {

--- a/components/opnpool/pool_task/network_msg.h
+++ b/components/opnpool/pool_task/network_msg.h
@@ -141,6 +141,11 @@ struct network_ctrl_set_ack_t {
     datalink_ctrl_typ_t  typ;  // type that it is ACK'ing
 } PACK8;
 
+struct network_ctrl_light_color_set_t {
+    uint8_t  color;    ///< Color mode byte (e.g. 0xC1=Blue, 0xB1=Party)
+    uint8_t  padding;  ///< Padding byte (0x00)
+} PACK8;
+
 struct network_ctrl_circuit_set_t {
     uint8_t  circuit_plus_1;
     uint8_t  value;
@@ -525,6 +530,7 @@ union network_data_a5_t {
     network_pump_status_resp_t     pump_status_resp;
     network_ctrl_set_ack_t         ctrl_set_ack;
     network_ctrl_circuit_set_t     ctrl_circuit_set;
+    network_ctrl_light_color_set_t ctrl_light_color_set;
     network_ctrl_sched_resp_t      ctrl_sched_resp;
     network_ctrl_state_bcast_t     ctrl_state_bcast;
     network_ctrl_time_t            ctrl_time;         // set or resp
@@ -599,6 +605,7 @@ union network_data_t {
     X(PUMP_STATUS_RESP,      sizeof(network_pump_status_resp_t),    false, A5_PUMP, datalink_pump_typ_t::STATUS)       \
     X(CTRL_SET_ACK,          sizeof(network_ctrl_set_ack_t),        false, A5_CTRL, datalink_ctrl_typ_t::SET_ACK)      \
     X(CTRL_CIRCUIT_SET,      sizeof(network_ctrl_circuit_set_t),    false, A5_CTRL, datalink_ctrl_typ_t::CIRCUIT_SET)  \
+    X(CTRL_LIGHT_COLOR_SET,  sizeof(network_ctrl_light_color_set_t),false, A5_CTRL, datalink_ctrl_typ_t::LIGHT_COLOR_SET) \
     X(CTRL_SCHED_REQ,        0,                                     false, A5_CTRL, datalink_ctrl_typ_t::SCHED_REQ)    \
     X(CTRL_SCHED_RESP,       sizeof(network_ctrl_sched_resp_t),     false, A5_CTRL, datalink_ctrl_typ_t::SCHED_RESP)   \
     X(CTRL_STATE_BCAST,      sizeof(network_ctrl_state_bcast_t),    false, A5_CTRL, datalink_ctrl_typ_t::STATE_BCAST)  \

--- a/components/opnpool/pool_task/network_msg.h
+++ b/components/opnpool/pool_task/network_msg.h
@@ -357,28 +357,30 @@ struct network_intellichem_t {
  * @note  Details at https://github.com/tagyoureit/nodejs-poolController/blob/master/controller/comms/messages/status/PumpStateMessage.ts#L27
  */
 
-enum class network_pump_reg_addr_t : uint8_t {
-    RPM        = 0x01,  // program RPM
-    POWER      = 0x02,  // program Power [Watt]
-    CURRENT    = 0x03,  // program Current [A]
-    STATUS     = 0x04,  // 0=off, 4=on, 10=running
-    SETPOINT   = 0x05,
-    TIMER_PROG = 0x06,
+/**
+ * @brief 16-bit pump register addresses (big-endian on the wire).
+ *
+ * @details A "set register" command (action REG, 0x01) carries the 2-byte
+ * register address followed by a 2-byte value. To set the running speed of an
+ * IntelliFlo VS pump the controller writes the RPM register 0x02C4, e.g. the
+ * payload {0x02, 0xC4, 0x05, 0xDC} commands 1500 RPM.
+ *
+ * @note These values are outside magic_enum's default range, so don't use
+ *       enum_str() on them; log them as a number instead.
+ */
+enum class network_pump_reg_addr_t : uint16_t {
+    RPM = 0x02C4,  ///< program/run RPM
 };
 
-struct network_pump_reg_operation_t {
-    uint8_t raw;
-
-    static constexpr uint8_t WRITE = 0xC4;
-    constexpr bool is_write() const { return raw == WRITE; }
-    constexpr char const * to_str() const { return raw == WRITE ? "WRITE" : "READ"; }
-} PACK8;
-
-
+/**
+ * @brief Pump "set register" payload (action REG, 0x01).
+ *
+ * @details The controller writes @ref value to the register at @ref address.
+ * Wire layout is 4 bytes: address.high, address.low, value.high, value.low.
+ */
 struct network_pump_reg_set_t {
-    network_pump_reg_addr_t      address;    // 0
-    network_pump_reg_operation_t operation;  // 1
-    network_hi_lo_t              value;      // 2..3  0x0000 for read operation
+    network_hi_lo_t address;  // 0..1  register address (e.g. 0x02C4 for RPM)
+    network_hi_lo_t value;    // 2..3  value to write
 } PACK8;
 
 struct network_pump_reg_resp_t {
@@ -479,8 +481,8 @@ struct network_chlor_model_req_t {
 } PACK8;
 
 struct network_chlor_model_resp_t {
-    uint8_t              salt;  ///< parts per million /50
-    network_chlor_name_t name;  ///< non-\0 terminated chlorinator name
+    uint8_t              unknown;  ///< leading byte; NOT salt (name string starts at offset 1)
+    network_chlor_name_t name;     ///< non-\0 terminated chlorinator name
 } PACK8;
 
 struct network_chlor_level_set_t {

--- a/components/opnpool/pool_task/network_rx.cpp
+++ b/components/opnpool/pool_task/network_rx.cpp
@@ -171,7 +171,7 @@ network_rx_msg(datalink_pkt_t const * const pkt, network_msg_t * const msg, bool
         // silently ignore packets that we don't know how to decode
     datalink_addr_t const dst = pkt->dst;
     if ((pkt->prot == datalink_prot_t::A5_CTRL && dst.is_unknown_90()) ||
-        (pkt->prot == datalink_prot_t::IC && !dst.is_broadcast() && !dst.is_chlorinator() )) {
+        (pkt->prot == datalink_prot_t::IC && !dst.is_all() && !dst.is_broadcast() && !dst.is_chlorinator() )) {
 
         *txOpportunity = false;
         msg->typ = network_msg_typ_t::IGNORE;

--- a/components/opnpool/pool_task/pool_task.cpp
+++ b/components/opnpool/pool_task/pool_task.cpp
@@ -67,6 +67,9 @@ constexpr uint32_t POOL_REQ_TASK_STACK_SIZE = 2 * 4096;   ///< Stack size for po
 /// Controller address learned from broadcast messages. Used as destination for outgoing requests.
 static datalink_addr_t _controller_addr = datalink_addr_t::unknown();
 
+/// A5 protocol version learned from controller broadcasts (0x01=EasyTouch, 0x31=SunTouch).
+static uint8_t _a5_ctrl_version = 0x01;
+
 
 /**
  * @brief Processes incoming packets from the RS-485 bus and relays messages to the main task.
@@ -96,7 +99,8 @@ _service_pkts_from_rs485(rs485_handle_t const rs485, ipc_t const * const ipc)
                 // snoop to find the controller address to use as the dst in _queue_req()
             if (msg.src.is_controller()) {
                 _controller_addr = msg.src;
-                ESP_LOGV(TAG, "learned controller address: 0x%02X", msg.src.addr);
+                _a5_ctrl_version = pkt.ver;
+                ESP_LOGV(TAG, "learned controller address: 0x%02X version: 0x%02X", msg.src.addr, pkt.ver);
             }
 
             if( ipc_send_network_msg_to_main_task(&msg, ipc) != ESP_OK) {
@@ -136,6 +140,7 @@ _service_requests_from_main(rs485_handle_t rs485, ipc_t const * const ipc)
 
         if (network_create_pkt(&msg, pkt) == ESP_OK) {
 
+            pkt->ver = _a5_ctrl_version;  // use learned controller version
             datalink_tx_pkt_queue(rs485, pkt);  // pkt and pkt->skb freed by recipient
             return;
         }
@@ -169,6 +174,7 @@ _queue_req(rs485_handle_t const rs485, network_msg_typ_t const typ)
 
     if (network_create_pkt(&msg, pkt) == ESP_OK) {
 
+        pkt->ver = _a5_ctrl_version;  // use learned controller version
         datalink_tx_pkt_queue(rs485, pkt);  // pkt and pkt->skb freed by mailbox recipient
 
     } else {

--- a/opnpool-1.yaml
+++ b/opnpool-1.yaml
@@ -29,19 +29,20 @@ logger:
   logs:
     rs485: VERBOSE
     datalink_rx: WARN      # VERBOSE to see the raw bytes
-    datalink_tx: WARN      # VERBOSE to see the raw bytes
+    datalink_tx: VERBOSE   # VERBOSE to see the raw bytes sent
     network_rx: WARN
     network_create: WARN
     pool_task: WARN
-    ipc: WARN
+    ipc: VERBOSE           # VERBOSE to see when commands are queued
     poolstate: WARN
     poolstate_rx: VERBOSE  # VERBOSE to see the decoded messages
     opnpool: WARN
     opnpool_climate: WARN
-    opnpool_switch: WARN
+    opnpool_switch: VERBOSE
     opnpool_sensor: WARN
     opnpool_binary_sensor: WARN
     opnpool_text_sensor: WARN
+    opnpool_number: WARN
     enum_helpers: WARN
 
 debug:
@@ -70,7 +71,7 @@ captive_portal:
 
 api:
   encryption:
-    key: !secret api_encryption_key 
+    key: !secret api_encryption_key
 
 ota:
   - platform: esphome
@@ -169,6 +170,13 @@ opnpool:
     name: "Pump speed"
     state_class: "measurement"
     unit_of_measurement: "rpm"
+  # optional: uncomment if a solar heater is connected
+  #solar_temperature:
+  #  name: "Solar temperature"
+  #  state_class: "measurement"
+  #  device_class: "temperature"
+  #  unit_of_measurement: "°F"
+
   chlorinator_level:
     name: "Chlorinator level"
     unit_of_measurement: "%"
@@ -176,6 +184,12 @@ opnpool:
     name: "Chlorinator salt"
     state_class: "measurement"
     unit_of_measurement: "ppm"
+
+  # number controls
+  primary_pump_speed_setpoint:
+    name: "Pump speed setpoint"
+  chlorinator_setpoint:
+    name: "Chlorinator setpoint"
 
   # binary sensors
   primary_pump_running:

--- a/opnpool-1.yaml
+++ b/opnpool-1.yaml
@@ -141,16 +141,17 @@ opnpool:
     state_class: "measurement"
     device_class: "temperature"
     unit_of_measurement: "°F"
-  solar1_temperature:
-    name: "Solar1 water"
-    state_class: "measurement"
-    device_class: "temperature"
-    unit_of_measurement: "°F"
-  solar2_temperature:
-    name: "Solar2 water"
-    state_class: "measurement"
-    device_class: "temperature"
-    unit_of_measurement: "°F"
+  # opt-in: uncomment only if you actually have solar temperature sensor(s)
+  #solar1_temperature:
+  #  name: "Solar1 water"
+  #  state_class: "measurement"
+  #  device_class: "temperature"
+  #  unit_of_measurement: "°F"
+  #solar2_temperature:
+  #  name: "Solar2 water"
+  #  state_class: "measurement"
+  #  device_class: "temperature"
+  #  unit_of_measurement: "°F"
   air_temperature:
     name: "Outside air"
     state_class: "measurement"
@@ -161,11 +162,13 @@ opnpool:
     state_class: "measurement"
     device_class: "power"
     unit_of_measurement: "W"
-  primary_pump_flow:
-    name: "Pump flow"
-    state_class: "measurement"
-    device_class: "volume_flow_rate"
-    unit_of_measurement: "gal/min"
+  # opt-in: variable-speed pumps (SuperFlo/IntelliFlo VS) always report 0 flow.
+  # uncomment only for a VF/VSF pump that actually reports GPM.
+  #primary_pump_flow:
+  #  name: "Pump flow"
+  #  state_class: "measurement"
+  #  device_class: "volume_flow_rate"
+  #  unit_of_measurement: "gal/min"
   primary_pump_speed:
     name: "Pump speed"
     state_class: "measurement"

--- a/opnpool-1.yaml
+++ b/opnpool-1.yaml
@@ -185,6 +185,10 @@ opnpool:
     state_class: "measurement"
     unit_of_measurement: "ppm"
 
+  # light color mode select
+  light_color:
+    name: "Light Color"
+
   # number controls
   primary_pump_speed_setpoint:
     name: "Pump speed setpoint"


### PR DESCRIPTION
## Summary

Adds several read/write equipment-control features on top of current `master`, organized into three focused commits. Per the earlier review feedback, the detailed-schedule (SCHEDS) import/export work is **intentionally excluded** from this PR and will follow as a separate one, so this set can be reviewed on its own.

## What's included

**IntelliChlor**
- Decode IntelliChlor responses addressed to the controller (dst `0x00`).
- Add a `chlorinator_setpoint` number (0–100%) that sends `CHLOR_LEVEL_SET` to the cell (`0x50`); the confirmed level is republished from pool state.
- Expose chlorinator salt, name, and status.
- Correct `network_chlor_model_resp_t` — the leading byte is not salt (the name string starts at offset 1).

**Pump**
- Add pump RPM control and speed reporting.

**Light**
- Add a light-color select entity that sends `CTRL_LIGHT_COLOR_SET`, so Home Assistant can switch the pool light color/show.

**Controller / fixes**
- Label the controller type as Easy/Sun Touch (firmware can't distinguish the two).
- Fix the circuit set command.

**Config ergonomics**
- `solar1_temperature`, `solar2_temperature`, and `primary_pump_flow` are now opt-in — created only when explicitly listed in YAML. Most systems have no solar sensors and variable-speed pumps always report 0 flow, so these otherwise showed up as useless zero/spurious entities.

## Not included (separate PR)

- EasyTouch detailed schedules (`SCHEDS` `0x91`) import/export + the Home Assistant `export_schedules` / `import_schedule` services.

## Notes

- Rebased cleanly onto current `master` — three focused commits, no merge commits, no schedule add/remove churn.
- No new required YAML; all new entities are opt-in, so existing configs are unaffected.

## Testing

- Built and running against a [Pentair EasyTouch — firmware x.xxx] controller. Chlorinator level/salt/name/status, pump RPM/speed, light color selection, and controller-type labeling all verified live; existing configs continue to work unchanged.